### PR TITLE
Feat | 웨이브 시스템 구현

### DIFF
--- a/Assets/00. Core/Spawner.cs
+++ b/Assets/00. Core/Spawner.cs
@@ -11,12 +11,12 @@ public abstract class Spawner<TInfo, TEnum> : MonoBehaviour
     [SerializeField]
     protected List<TInfo> _spawnedObjects = new List<TInfo>();
     [SerializeField]
-    protected float _spawnInterval = 3f;
+    protected float _spawnInterval;
     public float SpawnInterval { get => _spawnInterval; set => _spawnInterval = value; }
 
     [Header("Random Position Settings")]
     [SerializeField]
-    protected float _spawnRadius = 5f;
+    protected float _spawnRadius;
 
 
     private bool _isSpawning = true;

--- a/Assets/00. Core/Spawner.cs
+++ b/Assets/00. Core/Spawner.cs
@@ -12,6 +12,7 @@ public abstract class Spawner<TInfo, TEnum> : MonoBehaviour
     protected List<TInfo> _spawnedObjects = new List<TInfo>();
     [SerializeField]
     protected float _spawnInterval = 3f;
+    public float SpawnInterval { get => _spawnInterval; set => _spawnInterval = value; }
 
     [Header("Random Position Settings")]
     [SerializeField]

--- a/Assets/03. Mingyu/01. Scene/Test_Mingyu_FallScene.unity
+++ b/Assets/03. Mingyu/01. Scene/Test_Mingyu_FallScene.unity
@@ -238,17 +238,56 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 88ed818149f2a074da34fd86bf328c09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _isDontDestroy: 1
+  _isDontDestroy: 0
   _waveDatas:
   - EnemyStatMultiplier: 1
-    EnemySpawnerDelay: 5
+    EnemySpawnerInterval: 5
     WaveDuration: 60
   - EnemyStatMultiplier: 1.2
-    EnemySpawnerDelay: 4
+    EnemySpawnerInterval: 4
     WaveDuration: 60
   - EnemyStatMultiplier: 1.4
-    EnemySpawnerDelay: 3
+    EnemySpawnerInterval: 3
     WaveDuration: 60
+  _enemySpawnerHandler: {fileID: 1020366503}
+--- !u!4 &198910128 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+  m_PrefabInstance: {fileID: 6540084888712279087}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &379311706
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 379311707}
+  m_Layer: 0
+  m_Name: ===== [ Spawners ] =====
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &379311707
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 379311706}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1020366502}
+  - {fileID: 2105300391}
+  m_Father: {fileID: 2025868138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &605850599
 GameObject:
   m_ObjectHideFlags: 0
@@ -559,6 +598,51 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1020366501
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1020366502}
+  - component: {fileID: 1020366503}
+  m_Layer: 0
+  m_Name: === [ Enemy Spawners ] ===
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1020366502
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1020366501}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 198910128}
+  m_Father: {fileID: 379311707}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1020366503
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1020366501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e4f92d62922ba7946b798f2dffc8fede, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1247376324
 GameObject:
   m_ObjectHideFlags: 0
@@ -590,59 +674,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 605850600}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1431490418
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1431490419}
-  - component: {fileID: 1431490420}
-  m_Layer: 0
-  m_Name: PlayerMovableArea
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1431490419
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1431490418}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 10, y: 10, z: 10}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!65 &1431490420
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1431490418}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1449419992
 GameObject:
   m_ObjectHideFlags: 0
@@ -795,13 +826,76 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
+--- !u!1 &2025868137
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2025868138}
+  m_Layer: 0
+  m_Name: ======= [ System ] =======
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2025868138
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025868137}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 379311707}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2105300390
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2105300391}
+  m_Layer: 0
+  m_Name: === [ Debris Spawners ] ===
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2105300391
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2105300390}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 379311707}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &6540084888712279087
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 0}
+    m_TransformParent: {fileID: 1020366502}
     m_Modifications:
     - target: {fileID: 5184958744159570684, guid: bae079e521e79dc42972e7ad658636de, type: 3}
       propertyPath: m_Name
@@ -825,15 +919,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -860,6 +954,5 @@ SceneRoots:
   - {fileID: 1990100547}
   - {fileID: 605850600}
   - {fileID: 21432049}
-  - {fileID: 1431490419}
-  - {fileID: 6540084888712279087}
+  - {fileID: 2025868138}
   - {fileID: 952845320}

--- a/Assets/03. Mingyu/01. Scene/Test_Mingyu_FallScene.unity
+++ b/Assets/03. Mingyu/01. Scene/Test_Mingyu_FallScene.unity
@@ -502,6 +502,7 @@ GameObject:
   - component: {fileID: 952845319}
   - component: {fileID: 952845318}
   - component: {fileID: 952845317}
+  - component: {fileID: 952845321}
   m_Layer: 0
   m_Name: PlayerTest
   m_TagString: Player
@@ -598,6 +599,33 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!54 &952845321
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 952845316}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
 --- !u!1 &1020366501
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/03. Mingyu/01. Scene/Test_Mingyu_FallScene.unity
+++ b/Assets/03. Mingyu/01. Scene/Test_Mingyu_FallScene.unity
@@ -242,13 +242,13 @@ MonoBehaviour:
   _waveDatas:
   - EnemyStatMultiplier: 1
     EnemySpawnerInterval: 5
-    WaveDuration: 60
+    WaveDuration: 10
   - EnemyStatMultiplier: 1.2
     EnemySpawnerInterval: 4
-    WaveDuration: 60
+    WaveDuration: 10
   - EnemyStatMultiplier: 1.4
     EnemySpawnerInterval: 3
-    WaveDuration: 60
+    WaveDuration: 10
   _enemySpawnerHandler: {fileID: 1020366503}
 --- !u!4 &198910128 stripped
 Transform:

--- a/Assets/03. Mingyu/01. Scene/Test_Mingyu_FallScene.unity
+++ b/Assets/03. Mingyu/01. Scene/Test_Mingyu_FallScene.unity
@@ -132,6 +132,7 @@ GameObject:
   - component: {fileID: 21432051}
   - component: {fileID: 21432052}
   - component: {fileID: 21432053}
+  - component: {fileID: 21432054}
   m_Layer: 0
   m_Name: ======= [ Singleton ] =======
   m_TagString: Untagged
@@ -188,7 +189,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2b21113622f4a2b409c4ad985628848e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _isDontDestroy: 1
+  _isDontDestroy: 0
   _poolInfoList:
   - Type: 0
     InitCount: 100
@@ -206,7 +207,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a72a8767872aac248a5a3b1b19822cd9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _isDontDestroy: 1
+  _isDontDestroy: 0
   _poolInfoList:
   - Type: 0
     InitCount: 10
@@ -224,58 +225,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a0cfa01f18d5b7c4ebbc965bf16bcfee, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _isDontDestroy: 1
---- !u!1 &198910127
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 198910128}
-  - component: {fileID: 198910129}
-  m_Layer: 0
-  m_Name: EnemySpawner
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &198910128
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 198910127}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &198910129
+  _isDontDestroy: 0
+--- !u!114 &21432054
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 198910127}
+  m_GameObject: {fileID: 21432048}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5e509ca29f2ff2f4f85803e701590e37, type: 3}
+  m_Script: {fileID: 11500000, guid: 88ed818149f2a074da34fd86bf328c09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _spawnedObjects:
-  - ObjectType: 0
-    Probability: 100
-  - ObjectType: 1
-    Probability: 0
-  _spawnInterval: 3
-  _spawnRadius: 5
+  _isDontDestroy: 1
+  _waveDatas:
+  - EnemyStatMultiplier: 1
+    EnemySpawnerDelay: 5
+    WaveDuration: 60
+  - EnemyStatMultiplier: 1.2
+    EnemySpawnerDelay: 4
+    WaveDuration: 60
+  - EnemyStatMultiplier: 1.4
+    EnemySpawnerDelay: 3
+    WaveDuration: 60
 --- !u!1 &605850599
 GameObject:
   m_ObjectHideFlags: 0
@@ -822,6 +795,63 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
+--- !u!1001 &6540084888712279087
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5184958744159570684, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_Name
+      value: P_Spawner_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8847891133255138401, guid: bae079e521e79dc42972e7ad658636de, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bae079e521e79dc42972e7ad658636de, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -831,5 +861,5 @@ SceneRoots:
   - {fileID: 605850600}
   - {fileID: 21432049}
   - {fileID: 1431490419}
-  - {fileID: 198910128}
+  - {fileID: 6540084888712279087}
   - {fileID: 952845320}

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Data/EnemyData.cs
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Data/EnemyData.cs
@@ -26,4 +26,11 @@ public class EnemyData
 
     [ShowIf("EnemyType", EEnemyType.Bombing)]
     public float ExplosionRadius;
+
+    public void AdjustEnemyDataOnWave(float multiplier)
+    {
+        MaxHealth *= multiplier;
+        CurrentHealth *= multiplier;
+        AttackDamage *= multiplier;
+    }
 }

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/EnemySpawnerHandler.cs
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/EnemySpawnerHandler.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemySpawnerHandler : MonoBehaviour
+{
+    private List<EnemySpawner> _enemySpawners = new List<EnemySpawner>();
+    public List<EnemySpawner> EnemySpawners { get => _enemySpawners; set => _enemySpawners = value; }
+
+    private void Awake()
+    {
+        GetAllEnemySpawners();
+    }
+
+    private void GetAllEnemySpawners()
+    {
+        EnemySpawner[] enemySpawners = FindObjectsByType<EnemySpawner>(FindObjectsSortMode.None);
+        foreach (var spawner in enemySpawners)
+        {
+            _enemySpawners.Add(spawner);
+        }
+    }
+
+    public void AdjustSpawnerIntervalOnWave()
+    {
+        foreach (var spawner in _enemySpawners)
+        {
+            spawner.SpawnInterval = WaveManager.Instance.CurrentWaveData.EnemySpawnerInterval;
+        }
+    }
+}

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/EnemySpawnerHandler.cs.meta
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/EnemySpawnerHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e4f92d62922ba7946b798f2dffc8fede

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/WaveManager.cs
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/WaveManager.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public struct WaveData
+{
+    public float EnemyStatMultiplier;
+    public float EnemySpawnerInterval;
+    public float WaveDuration; 
+}
+
+public class WaveManager : Singleton<WaveManager>
+{
+    [Header("Wave Data")]
+    [SerializeField]
+    private List<WaveData> _waveDatas = new List<WaveData>();
+
+    private WaveData _currentWaveData;
+    public WaveData CurrentWaveData 
+    { 
+        get => _currentWaveData; 
+        set
+        {
+            _currentWaveData = value;
+            _spawnerHandler.AdjustSpawnerIntervalOnWave();
+            // TODO : 웨이브가 바뀜을 보여주는 UI
+        }
+    }
+
+    [Header("External References")]
+    [SerializeField]
+    private EnemySpawnerHandler _spawnerHandler;
+
+    private int _currentWaveIndex;
+    private float _currentWaveStartTime;
+
+    protected override void Awake()
+    {
+        base.Awake();
+    }
+
+    private void Start()
+    {
+        _currentWaveData = _waveDatas[_currentWaveIndex];
+    }
+
+    private void Update()
+    {
+        if (_currentWaveStartTime + _waveDatas[_currentWaveIndex].WaveDuration <= Time.time)
+        {
+            ChangeWave();
+        }
+    }
+
+    private void ChangeWave()       
+    {
+        _currentWaveIndex++;
+        if (_currentWaveIndex < _waveDatas.Count)
+        {
+            _currentWaveData = _waveDatas[_currentWaveIndex];
+            _currentWaveStartTime = Time.time;
+        }
+        else
+        {
+            _currentWaveIndex = 0;
+            // TODO : 추락 씬에서 보스 씬으로 이동
+        }
+    }
+}

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/WaveManager.cs
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/WaveManager.cs
@@ -23,14 +23,14 @@ public class WaveManager : Singleton<WaveManager>
         set
         {
             _currentWaveData = value;
-            _spawnerHandler.AdjustSpawnerIntervalOnWave();
+            _enemySpawnerHandler.AdjustSpawnerIntervalOnWave();
             // TODO : 웨이브가 바뀜을 보여주는 UI
         }
     }
 
     [Header("External References")]
     [SerializeField]
-    private EnemySpawnerHandler _spawnerHandler;
+    private EnemySpawnerHandler _enemySpawnerHandler;
 
     private int _currentWaveIndex;
     private float _currentWaveStartTime;
@@ -42,7 +42,7 @@ public class WaveManager : Singleton<WaveManager>
 
     private void Start()
     {
-        _currentWaveData = _waveDatas[_currentWaveIndex];
+        CurrentWaveData = _waveDatas[_currentWaveIndex];
     }
 
     private void Update()
@@ -58,7 +58,7 @@ public class WaveManager : Singleton<WaveManager>
         _currentWaveIndex++;
         if (_currentWaveIndex < _waveDatas.Count)
         {
-            _currentWaveData = _waveDatas[_currentWaveIndex];
+            CurrentWaveData = _waveDatas[_currentWaveIndex];
             _currentWaveStartTime = Time.time;
         }
         else

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/WaveManager.cs
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/WaveManager.cs
@@ -54,7 +54,7 @@ public class WaveManager : Singleton<WaveManager>
     }
 
     private void ChangeWave()       
-    {
+    { 
         _currentWaveIndex++;
         if (_currentWaveIndex < _waveDatas.Count)
         {

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/WaveManager.cs.meta
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/Spawner/WaveManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88ed818149f2a074da34fd86bf328c09

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/State/EnemyController.cs
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/State/EnemyController.cs
@@ -42,8 +42,6 @@ public class EnemyController : MonoBehaviour, IDamageable
         _enemyCollider = GetComponent<CapsuleCollider>();
         _enemyAnimator = GetComponent<Animator>();
 
-        _enemyData = _enemyDataSO.GetEnemyData(_enemyType);
-
         _player = GameObject.FindGameObjectWithTag(nameof(ETags.Player));
     }
 
@@ -52,6 +50,8 @@ public class EnemyController : MonoBehaviour, IDamageable
         if (_enemyStateDict.Count != 0)
         {
             _enemyStateContext.ChangeState(_enemyStateDict[EEnemyState.Trace]);
+            _enemyData = _enemyDataSO.GetEnemyData(_enemyType);
+            _enemyData.AdjustEnemyDataOnWave(WaveManager.Instance.CurrentWaveData.EnemyStatMultiplier);
         }
     }
     private void Start()

--- a/Assets/03. Mingyu/02. Scripts/02-3. Enemy/State/EnemyController.cs
+++ b/Assets/03. Mingyu/02. Scripts/02-3. Enemy/State/EnemyController.cs
@@ -42,6 +42,7 @@ public class EnemyController : MonoBehaviour, IDamageable
         _enemyCollider = GetComponent<CapsuleCollider>();
         _enemyAnimator = GetComponent<Animator>();
 
+        _enemyData = _enemyDataSO.GetEnemyData(_enemyType);
         _player = GameObject.FindGameObjectWithTag(nameof(ETags.Player));
     }
 

--- a/Assets/03. Mingyu/02. Scripts/02-4. Bullet.meta
+++ b/Assets/03. Mingyu/02. Scripts/02-4. Bullet.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 966d0f99c8f86774689e94d3efaee485
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/03. Mingyu/03. Prefabs/Enemy/P_Enemy_Bombing.prefab
+++ b/Assets/03. Mingyu/03. Prefabs/Enemy/P_Enemy_Bombing.prefab
@@ -105,7 +105,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2

--- a/Assets/03. Mingyu/03. Prefabs/Enemy/P_Enemy_Shooting.prefab
+++ b/Assets/03. Mingyu/03. Prefabs/Enemy/P_Enemy_Shooting.prefab
@@ -105,7 +105,7 @@ CapsuleCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 1
+  m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2

--- a/Assets/03. Mingyu/03. Prefabs/Spawner.meta
+++ b/Assets/03. Mingyu/03. Prefabs/Spawner.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 821e79884bbe6aa42917b9e80c091f7f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/03. Mingyu/03. Prefabs/Spawner/P_Spawner_Enemy.prefab
+++ b/Assets/03. Mingyu/03. Prefabs/Spawner/P_Spawner_Enemy.prefab
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5184958744159570684
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8847891133255138401}
+  - component: {fileID: 7778307424478090956}
+  m_Layer: 0
+  m_Name: P_Spawner_Enemy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8847891133255138401
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5184958744159570684}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7778307424478090956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5184958744159570684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5e509ca29f2ff2f4f85803e701590e37, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _spawnedObjects:
+  - ObjectType: 0
+    Probability: 100
+  - ObjectType: 1
+    Probability: 0
+  _spawnInterval: 3
+  _spawnRadius: 5

--- a/Assets/03. Mingyu/03. Prefabs/Spawner/P_Spawner_Enemy.prefab.meta
+++ b/Assets/03. Mingyu/03. Prefabs/Spawner/P_Spawner_Enemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bae079e521e79dc42972e7ad658636de
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
1. 추락 씬에서의 웨이브 시스템을 관리하는 WaveManager를 구현했습니다.
2. 웨이브 변화에 따른 스탯 변화값과 웨이브 지속시간을 저장하는 WaveData 구조체를 통해 웨이브를 관리합니다.
3. 웨이브 변화시, EnemySpawnerHandler를 통해 모든 스포너의 스폰 인터벌을 조정해줬습니다.
4. Enemy의 경우, 풀에서 가져올 때(활성화될 때) EnemyDataSO에서 기본 데이터를 가져오면서 현재 웨이브의 스탯 보정계수를 곱해주는 방식으로 구현했습니다. 