### PR TITLE
Feat | 로비씬 -> 추락씬 전환 구현

### DIFF
--- a/Assets/00. MaIn/01. Scenes/BossScene.unity
+++ b/Assets/00. MaIn/01. Scenes/BossScene.unity
@@ -1629,72 +1629,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &926509471
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1706294266}
-    m_Modifications:
-    - target: {fileID: 3982908443603302322, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_Name
-      value: PerkManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 4348055446268168251, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: _isDontDestroy
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
---- !u!4 &926509472 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-  m_PrefabInstance: {fileID: 926509471}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &933059195
 GameObject:
   m_ObjectHideFlags: 0
@@ -2463,7 +2397,6 @@ Transform:
   - {fileID: 208229711}
   - {fileID: 1339800740}
   - {fileID: 94855699}
-  - {fileID: 926509472}
   - {fileID: 933059196}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/00. MaIn/01. Scenes/FallScene.unity
+++ b/Assets/00. MaIn/01. Scenes/FallScene.unity
@@ -422,72 +422,6 @@ Transform:
   - {fileID: 1887002312}
   m_Father: {fileID: 1493046136}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &262367439
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 751054933}
-    m_Modifications:
-    - target: {fileID: 3982908443603302322, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_Name
-      value: PerkManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 4348055446268168251, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: _isDontDestroy
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
---- !u!4 &262367440 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
-  m_PrefabInstance: {fileID: 262367439}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &328006125
 GameObject:
   m_ObjectHideFlags: 0
@@ -566,22 +500,6 @@ MonoBehaviour:
   - Type: 2
     InitCount: 100
     Prefab: {fileID: 5356239073171952968, guid: be1360722e376c944b6971183ac40e0d, type: 3}
-    Container: {fileID: 2024478837}
-  - Type: 3
-    InitCount: 20
-    Prefab: {fileID: 1331364910304127374, guid: ec7d5d86672ae5749ab16bde84af1741, type: 3}
-    Container: {fileID: 2024478837}
-  - Type: 4
-    InitCount: 5
-    Prefab: {fileID: 1331364910304127374, guid: cf9ea3f9c3840b948ab7218b6d14d185, type: 3}
-    Container: {fileID: 2024478837}
-  - Type: 5
-    InitCount: 5
-    Prefab: {fileID: 1331364910304127374, guid: ec7d5d86672ae5749ab16bde84af1741, type: 3}
-    Container: {fileID: 2024478837}
-  - Type: 6
-    InitCount: 5
-    Prefab: {fileID: 4495356607337096260, guid: 5d1dda986c1e5974c854d93a54eb9676, type: 3}
     Container: {fileID: 2024478837}
 --- !u!4 &402780793
 Transform:
@@ -920,7 +838,6 @@ Transform:
   - {fileID: 1332452640}
   - {fileID: 1145077312}
   - {fileID: 1699406578}
-  - {fileID: 262367440}
   - {fileID: 1809007077}
   - {fileID: 580858358}
   m_Father: {fileID: 0}
@@ -1561,12 +1478,80 @@ MonoBehaviour:
   _isDontDestroy: 0
   _poolInfoList:
   - Type: 0
-    InitCount: 10
+    InitCount: 3
     Prefab: {fileID: 1911891793528327492, guid: ab8ae4b20acf20742952a4faa906a0a6, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 3
+    Prefab: {fileID: 1911891793528327492, guid: d2c5884d2dbdf494a917dfaa044af16f, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 3
+    Prefab: {fileID: 1911891793528327492, guid: 5557e762427a70b45a219a0a7e55c410, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 3
+    Prefab: {fileID: 1911891793528327492, guid: 8f16b0ea68314e54badc3b144aed3040, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 3
+    Prefab: {fileID: 1911891793528327492, guid: a5b2ceb43985af946bbc6114797963a9, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 3
+    Prefab: {fileID: 1911891793528327492, guid: b37ad09ebcc7d3f48aa4c9ed18e027c1, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 43a1ce17afc301844ad823aa9c0cec08, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 9c319e906bd4aff4b96160369c41dd80, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 12ae601ba22263746adbbe2945a962b2, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 51158861593b0db4ebc8ae11e8d5bb4d, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: dbfa5d2a060f0cf4992a51102080f7f5, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 0b93fb7d887e8344582aad00de630beb, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 6a204d5c6bf20b24481008cdea1cbd09, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 0
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 426c5d71d8e106e47ad7c740d0a77fb4, type: 3}
     Container: {fileID: 754023153}
   - Type: 1
     InitCount: 10
-    Prefab: {fileID: 2992496205141319093, guid: d50b563234c0bff42b341eb3dfe96963, type: 3}
+    Prefab: {fileID: 1911891793528327492, guid: be303240203bdb940881129e85b868eb, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 1
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 425250f1c53ab3a40bb03342cbffdf4d, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 1
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: de086bc12a566f34db928e3ef8421933, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 1
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 2ec086cb06c2e9644b8b9d0d47de3bff, type: 3}
+    Container: {fileID: 754023153}
+  - Type: 1
+    InitCount: 10
+    Prefab: {fileID: 1911891793528327492, guid: 99beda4896382a34c9ed055392a8f1e3, type: 3}
     Container: {fileID: 754023153}
 --- !u!4 &1332452640
 Transform:
@@ -1851,38 +1836,6 @@ Transform:
   m_Children:
   - {fileID: 244308124}
   - {fileID: 1977620688}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1557832469
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1557832470}
-  m_Layer: 0
-  m_Name: ======= [ Singleton - DontDestroy ] =======
-  m_TagString: Manager
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1557832470
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1557832469}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1873471868}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1573208507
@@ -2255,51 +2208,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ab084b3110128dd43a06740d48d17918, type: 3}
---- !u!1 &1873471867
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1873471868}
-  - component: {fileID: 1873471869}
-  m_Layer: 0
-  m_Name: SceneTransitionManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1873471868
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1873471867}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1557832470}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1873471869
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1873471867}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a9303d6d0d735b840a69a48b8937fd89, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _isDontDestroy: 1
 --- !u!1 &1887002310
 GameObject:
   m_ObjectHideFlags: 0
@@ -2703,7 +2611,6 @@ SceneRoots:
   - {fileID: 487213794}
   - {fileID: 7822619764561335532}
   - {fileID: 957422398}
-  - {fileID: 1557832470}
   - {fileID: 751054933}
   - {fileID: 328006126}
   - {fileID: 29799}

--- a/Assets/00. MaIn/01. Scenes/LobbyScene.unity
+++ b/Assets/00. MaIn/01. Scenes/LobbyScene.unity
@@ -374,7 +374,9 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1349985675}
+  - {fileID: 251834949}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &155877230
@@ -411,6 +413,72 @@ Transform:
   - {fileID: 42498569}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &251834948
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 131000592}
+    m_Modifications:
+    - target: {fileID: 3982908443603302322, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_Name
+      value: PerkManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 4348055446268168251, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: _isDontDestroy
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+--- !u!4 &251834949 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6453233056651548470, guid: 426c4474083b7c246a908c0a50dac9a4, type: 3}
+  m_PrefabInstance: {fileID: 251834948}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &254092416
 GameObject:
   m_ObjectHideFlags: 0
@@ -746,52 +814,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 644557c488d6e61478735c23c01e2408, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &895750790
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 895750792}
-  - component: {fileID: 895750791}
-  m_Layer: 0
-  m_Name: PerkManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &895750791
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 895750790}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a30795186a00d364395be67889e66bbc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _isDontDestroy: 1
-  _perkDataCollection: {fileID: 11400000, guid: cd0bbfa18afdd224888ad69610e69697, type: 2}
---- !u!4 &895750792
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 895750790}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1238183771}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &923448801
 GameObject:
   m_ObjectHideFlags: 0
@@ -1223,7 +1245,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8648331110355574915}
-  - {fileID: 895750792}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1299071172
@@ -1301,6 +1322,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1299071172}
   m_CullTransparentMesh: 1
+--- !u!1 &1349985674
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1349985675}
+  - component: {fileID: 1349985676}
+  m_Layer: 0
+  m_Name: SceneTransitionManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1349985675
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1349985674}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 131000592}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1349985676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1349985674}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a9303d6d0d735b840a69a48b8937fd89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _isDontDestroy: 1
 --- !u!1 &1717584961
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/02. Mir/02. Scripts/Lobby_Misc/LobbySceneManager.cs
+++ b/Assets/02. Mir/02. Scripts/Lobby_Misc/LobbySceneManager.cs
@@ -92,7 +92,6 @@ public class LobbySceneManager : Singleton<LobbySceneManager>
     public void OnClickedGameStart()
     {
         Debug.Log("Scene Load");
-
-        // SceneTransitionManager.Instance.LoadScene("FallScene");
+        SceneTransitionManager.Instance.LoadScene(nameof(ESceneNames.FallScene));
     }
 }


### PR DESCRIPTION
### ※ PR 작성 전 체크리스트 ※
1. 작업하신 브랜치가 최신화되었나요? (behind 커밋이 존재하지 않나요?) 네
2. 추가하신 기능 및 전체 로직이 정상적으로 동작하는 것을 확인하셨나요? (기능 테스트를 완료하셨나요?) 네
<br/>

### 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.(이미지 첨부 가능)
<br/>
1. 로비씬 Start 버튼 클릭 시, FallScene으로의 전환을 구현했습니다
2. 이 과정에서 발생한 Hierarchy 미할당 이슈를 해결하고, 모든 DontDestory 싱글톤 매니저들을 LobbyScene으로 이관했습니다.


### ⏱️예상 리뷰 시간 : 10s
<br/>

### 📷이슈 번호(선택)
> 생성된 이슈에 대한 PR일 경우, 이슈 번호를 적어주세요. <br/>
<br/>

### 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.<br/>
